### PR TITLE
[Improvement] Idea Registrations List as Dynamic CSV

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
     "content-hash": "6c81b1ce00736977bc448b45fc089378",
@@ -66,16 +66,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v4.2.3",
+            "version": "v4.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "d461670ee145092b7e2a56c1da7118f19cadadb0"
+                "reference": "761fa560a937fd7686e5274ff89dcfa87a5047df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/d461670ee145092b7e2a56c1da7118f19cadadb0",
-                "reference": "d461670ee145092b7e2a56c1da7118f19cadadb0",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/761fa560a937fd7686e5274ff89dcfa87a5047df",
+                "reference": "761fa560a937fd7686e5274ff89dcfa87a5047df",
                 "shasum": ""
             },
             "require": {
@@ -121,7 +121,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-16T20:35:37+00:00"
+            "time": "2019-02-23T15:17:42+00:00"
         }
     ],
     "packages-dev": [

--- a/lib/Idea.php
+++ b/lib/Idea.php
@@ -27,4 +27,15 @@ class Idea {
         $part = \Symfony\Component\Yaml\Yaml::dump($this->$data);
         return TeamUpdate::sendUpdate(sprintf(IDEA_TG_MESSAGE, $part));
     }
+
+    public static function reglist() {
+        $sql = "SELECT * FROM idea";
+        $db = new Database;
+        $stmt = $db->query($sql, []);
+        $records = array();
+        foreach($stmt as $row) {
+            $records[] = $row;
+        }
+        return $records;
+    }
 }

--- a/www/idea.csv/index.php
+++ b/www/idea.csv/index.php
@@ -1,0 +1,28 @@
+<?php
+define('CSV_LIMIT', 5); // in MiB
+
+header('Content-Type: application/csv');
+$csv_file = fopen('php://temp/maxmemory:'.(CSV_LIMIT * 1024 * 1024), 'r+');
+# for header line
+fputcsv(
+    $csv_file, array(
+        'name1', 'name2', 'name3', 
+        'email1', 'email2', 'email3',
+        'phone1', 'phone2', 'phone3', 
+        'university', 'state', 'pincode',
+        'city', 'title', 'idea_desc',
+        'stage', 'paytm'
+    )
+);
+
+require('../../vendor/autoload.php');
+
+# for registration record(s) line(s)
+foreach(Idea::reglist() as $reg_record) {
+    fputcsv($csv_file, $reg_record);
+}
+
+rewind($csv_file);
+$out = stream_get_contents($csv_file);
+echo $out;
+?>

--- a/www/idea.csv/index.php
+++ b/www/idea.csv/index.php
@@ -1,8 +1,8 @@
 <?php
-define('CSV_LIMIT', 5); // in MiB
+define('FILE_MEM_LIMIT', 10); // in MiB
 
 header('Content-Type: application/csv');
-$csv_file = fopen('php://temp/maxmemory:'.(CSV_LIMIT * 1024 * 1024), 'r+');
+$csv_file = fopen('php://temp/maxmemory:'.(FILE_MEM_LIMIT * 1024 * 1024), 'r+');
 # for header line
 fputcsv(
     $csv_file, array(


### PR DESCRIPTION
# Background

The IDEA'19 team required a plain spreadsheet containing always updated registration records for their event.

# Workaround

A folder has been created named idea.csv, underneath which index.php script has been placed which is capable of rendering CSV contents of the entire registration records present in the database. Upon creation of this PR, a Heroku app will be automatically created for review purposes since this repository is directly integrated with a Heroku workflow.

Using the review app **/idea.csv** link will allow users to download the CSV file from the browser.

For this functionality to be available, the following code changes have been made:
- Added a static function named reglist() in class Idea (file: lib/Idea)
- Added a script idea.csv/index.php which actually renders the CSV content (file: www/idea.csv/index.php)

https://github.com/gdgu/ecellgdgu/blob/b290ec35f022980e1d9387eb2deac5f7cb56f4c7/www/idea.csv/index.php#L1-L28

**Request you to merge this PR, whenever possible.**
Thanks in advance.